### PR TITLE
Add summarizer agent

### DIFF
--- a/apps/summarizer-agent/package.json
+++ b/apps/summarizer-agent/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "summarizer-agent",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch src/server.ts",
+    "start": "node dist/server.js",
+    "test": "jest",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src/**/*.ts",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "winston": "^3.11.0",
+    "zod": "^3.22.4",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "@types/uuid": "^9.0.7",
+    "tsx": "^4.6.0"
+  }
+}

--- a/apps/summarizer-agent/src/server.ts
+++ b/apps/summarizer-agent/src/server.ts
@@ -1,0 +1,153 @@
+/**
+ * Summarizer Agent
+ *
+ * Generates unified responses from raw tool results.
+ */
+
+import { v4 as uuidv4 } from 'uuid'
+
+// Basic types mirroring the Location Agent structures
+interface SummarizeRequest {
+  query: string
+  intent: string
+  toolResults: Array<{ tool: string; result: any }>
+  context?: Record<string, any>
+}
+
+interface SummarizeResponse {
+  id: string
+  summary: string
+  reasoning: string[]
+  escalate: null | 'clarify' | 'summary'
+  status: 'success' | 'error'
+}
+
+interface AgentManifest {
+  agentId: string
+  name: string
+  description: string
+  version: string
+  tools: Array<{
+    name: string
+    description: string
+    intentTags: string[]
+    schema: any
+  }>
+  capabilities: string[]
+  expertise: string[]
+  healthEndpoint: string
+  status: string
+}
+
+interface AgentCard {
+  agentId: string
+  name: string
+  description: string
+  version: string
+  capabilities: string[]
+  expertise: string[]
+}
+
+class SummarizerAgentServer {
+  private agentCard: AgentCard
+  private isRunning = false
+
+  constructor() {
+    this.agentCard = {
+      agentId: 'summarizer-agent-001',
+      name: 'Warehouse Summarizer Agent',
+      description: 'Generates final user friendly summaries from raw tool results',
+      version: '1.0.0',
+      capabilities: ['response_generation', 'multi_tool_summary'],
+      expertise: ['reporting', 'warehouse_insights']
+    }
+  }
+
+  async start(): Promise<void> {
+    console.log('🚀 Starting Summarizer Agent...')
+    this.isRunning = true
+    console.log(`✅ Summarizer Agent "${this.agentCard.name}" is ready!`)
+  }
+
+  async stop(): Promise<void> {
+    console.log('🛑 Stopping Summarizer Agent...')
+    this.isRunning = false
+    console.log('✅ Summarizer Agent stopped')
+  }
+
+  async healthCheck(): Promise<{ status: string }> {
+    return { status: this.isRunning ? 'healthy' : 'unhealthy' }
+  }
+
+  getManifest(): AgentManifest {
+    return {
+      agentId: this.agentCard.agentId,
+      name: this.agentCard.name,
+      description: this.agentCard.description,
+      version: this.agentCard.version,
+      tools: [
+        {
+          name: 'summarize_results',
+          description: 'Combine multiple tool outputs into a single summary',
+          intentTags: ['summarize', 'combine', 'report'],
+          schema: {
+            type: 'object',
+            properties: {
+              query: { type: 'string' },
+              intent: { type: 'string' },
+              toolResults: { type: 'array' }
+            },
+            required: ['query', 'toolResults']
+          }
+        }
+      ],
+      capabilities: this.agentCard.capabilities,
+      expertise: this.agentCard.expertise,
+      healthEndpoint: '/health',
+      status: this.isRunning ? 'healthy' : 'unhealthy'
+    }
+  }
+
+  async processMessage(request: SummarizeRequest): Promise<SummarizeResponse> {
+    if (!this.isRunning) {
+      throw new Error('Summarizer Agent is not running')
+    }
+
+    const reasoning: string[] = []
+    reasoning.push('Combining tool results')
+
+    let summary = `**Summary for:** "${request.query}"\n\n`
+
+    for (const entry of request.toolResults) {
+      const result = entry.result
+      let snippet = ''
+
+      if (result && typeof result === 'object') {
+        if (result.summary) {
+          snippet = JSON.stringify(result.summary)
+        } else if (Array.isArray(result.items)) {
+          snippet = `${result.items.length} items`
+        } else {
+          snippet = Object.keys(result).slice(0, 3).join(', ')
+        }
+      } else {
+        snippet = String(result)
+      }
+
+      summary += `• From ${entry.tool}: ${snippet}\n`
+    }
+
+    summary += '\n_All data sourced from warehouse tools._'
+
+    return {
+      id: uuidv4(),
+      summary,
+      reasoning,
+      escalate: null,
+      status: 'success'
+    }
+  }
+}
+
+export const summarizerAgent = new SummarizerAgentServer()
+

--- a/apps/summarizer-agent/src/test-summarizer.ts
+++ b/apps/summarizer-agent/src/test-summarizer.ts
@@ -1,0 +1,28 @@
+import { summarizerAgent } from './server.js'
+
+async function runTest() {
+  await summarizerAgent.start()
+
+  const request = {
+    query: 'Where is product 12345?',
+    intent: 'location_query',
+    toolResults: [
+      { tool: 'find_product_locations', result: { products: [{ productNumber: '12345', areaId: 'D' }] } },
+      { tool: 'analyze_space_utilization', result: { summary: { overallUtilization: 80 } } }
+    ]
+  }
+
+  const response = await summarizerAgent.processMessage(request)
+  console.log(response.summary)
+
+  await summarizerAgent.stop()
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runTest().catch(err => {
+    console.error('Test failed', err)
+    process.exit(1)
+  })
+}
+
+export { runTest }

--- a/apps/summarizer-agent/tsconfig.json
+++ b/apps/summarizer-agent/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../../packages/types" },
+    { "path": "../../packages/config" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add new `summarizer-agent` workspace
- implement minimal SummarizerAgentServer with manifest and processMessage
- include example test script for summarizer agent

## Testing
- `npm test` *(fails: config package has no tests)*

------
https://chatgpt.com/codex/tasks/task_e_685038a4ff0883258626f4850c802590